### PR TITLE
#54865 Call get_export_products only once per job to avoid crashing on failed calls

### DIFF
--- a/src/gobdistribute/distribute.py
+++ b/src/gobdistribute/distribute.py
@@ -7,9 +7,11 @@ import tempfile
 from gobconfig.datastore.config import get_datastore_config
 from gobcore.datastore.factory import Datastore, DatastoreFactory
 from gobcore.datastore.objectstore import ObjectDatastore, get_full_container_list, get_object
+from gobcore.exceptions import GOBException
 from gobcore.logging.logger import logger
 from pathlib import Path
 from typing import List, Tuple
+from requests.exceptions import ConnectionError
 
 from gobdistribute.config import CONTAINER_BASE, EXPORT_API_HOST, GOB_OBJECTSTORE
 from gobdistribute.utils import json_loads
@@ -89,7 +91,12 @@ def _get_export_products(catalogue: str):
     :return:
     """
     r = requests.get(f'{EXPORT_API_HOST}/products')
-    r.raise_for_status()
+    try:
+        r.raise_for_status()
+    except ConnectionError:
+        logger.error("Fetching export products from GOB-Export failed")
+        raise GOBException("Fetching export products from GOB-Export failed")
+
     data = json.loads(r.text)
     return data.get(catalogue)
 

--- a/src/gobdistribute/distribute.py
+++ b/src/gobdistribute/distribute.py
@@ -50,6 +50,7 @@ def distribute(catalogue, fileset=None):
 
     # Get distribute configuration for the given catalogue, if a product is provided select only that product
     distribute_filesets = _get_config(conn_info, catalogue, container_name)
+    export_products = _get_export_products(catalogue)
 
     logger.info("Disconnect from Objectstore")
     datastore.disconnect()
@@ -60,7 +61,7 @@ def distribute(catalogue, fileset=None):
         logger.info(f"Download fileset {fileset}")
         temp_fileset_dir = os.path.join(tempfile.gettempdir(), fileset)
 
-        filenames = _get_filenames(conn_info, config, catalogue)
+        filenames = _get_filenames(conn_info, config, catalogue, export_products)
         src_files = _download_sources(conn_info, temp_fileset_dir, filenames)
 
         for destination in config.get('destinations', []):
@@ -116,7 +117,7 @@ def _dst_path(source_file_path: str, base_dir: str):
     return source_file_path.replace(base_dir, "")
 
 
-def _get_filenames(conn_info: dict, config: dict, catalogue: str) -> List[Tuple[str, str]]:
+def _get_filenames(conn_info: dict, config: dict, catalogue: str, export_products: dict) -> List[Tuple[str, str]]:
     """Determines filenames to download for sources in config.
 
     Source should have either 'file_name' or 'export' set. When source is 'file_name', this name is used. When source
@@ -129,7 +130,6 @@ def _get_filenames(conn_info: dict, config: dict, catalogue: str) -> List[Tuple[
     :return:
     """
     # Download exports product definition
-    export_products = _get_export_products(catalogue)
     filenames = []
 
     logger.info("Determining files from source to distribute")

--- a/src/tests/test_distribute.py
+++ b/src/tests/test_distribute.py
@@ -14,11 +14,12 @@ class TestDistribute(TestCase):
     @patch('gobdistribute.distribute._get_datastore')
     @patch('gobdistribute.distribute._get_config')
     @patch('gobdistribute.distribute._get_filenames')
+    @patch('gobdistribute.distribute._get_export_products')
     @patch('gobdistribute.distribute._download_sources')
     @patch('gobdistribute.distribute._distribute_files')
     @patch('gobdistribute.distribute.CONTAINER_BASE', 'THE_CONTAINER')
     @patch('gobdistribute.distribute.tempfile.gettempdir', lambda: '/tmpdir')
-    def test_distribute(self, mock_distribute_files, mock_download_sources, mock_get_filenames,
+    def test_distribute(self, mock_distribute_files, mock_download_sources, mock_get_export_products, mock_get_filenames,
                         mock_get_config, mock_get_datastore):
         catalogue = 'any catalogue'
         fileset = 'fileset_a'
@@ -74,27 +75,33 @@ class TestDistribute(TestCase):
 
         mock_get_config.assert_called_with(conn_info, catalogue, 'THE_CONTAINER')
         mock_get_filenames.assert_has_calls([
-            call(conn_info, mock_get_config.return_value['fileset_a'], catalogue),
-            call(conn_info, mock_get_config.return_value['fileset_b'], catalogue),
+            call(conn_info, mock_get_config.return_value['fileset_a'], catalogue, mock_get_export_products.return_value),
+            call(conn_info, mock_get_config.return_value['fileset_b'], catalogue, mock_get_export_products.return_value),
         ])
         mock_download_sources.assert_has_calls([
             call(conn_info, '/tmpdir/fileset_a', mock_get_filenames()),
             call(conn_info, '/tmpdir/fileset_b', mock_get_filenames()),
         ])
+        mock_get_export_products.assert_called_with(catalogue)
+        mock_get_export_products.assert_called_once()
 
         # Reset mocks. Test with only one fileset
         mock_download_sources.reset_mock()
         mock_get_filenames.reset_mock()
+        mock_get_export_products.reset_mock()
 
         distribute(catalogue, fileset)
 
         mock_get_filenames.assert_has_calls([
-            call(conn_info, mock_get_config.return_value['fileset_a'], catalogue),
+            call(conn_info, mock_get_config.return_value['fileset_a'], catalogue, mock_get_export_products.return_value),
         ])
 
         mock_download_sources.assert_has_calls([
             call(conn_info, '/tmpdir/fileset_a', mock_get_filenames()),
         ])
+
+        mock_get_export_products.assert_called_with(catalogue)
+        mock_get_export_products.assert_called_once()
 
     @patch('gobdistribute.distribute.requests')
     @patch('gobdistribute.distribute.EXPORT_API_HOST', 'http://exportapihost')
@@ -151,9 +158,8 @@ class TestDistribute(TestCase):
         mock_get_list.assert_called_with('CONNECTION', 'CONTAINER')
 
     @patch('gobdistribute.distribute._expand_filename_wildcard')
-    @patch('gobdistribute.distribute._get_export_products')
-    def test_get_filenames(self, mock_get_export_products, mock_expand_wildcard):
-        mock_get_export_products.return_value = {
+    def test_get_filenames(self, mock_expand_wildcard):
+        export_products = {
             'collection1': {
                 'product1': [
                     'file1.csv',
@@ -220,8 +226,7 @@ class TestDistribute(TestCase):
             ('catalog1/file3.dat', 'catalog1/file3.dat'),
             ('catalog1/file5.csv', 'catalog1/file5.csv'),
             ('catalog1/file6.shp', 'catalog1/file6.shp')
-        ], _get_filenames(conn_info, config, 'catalog1'))
-        mock_get_export_products.assert_called_with('catalog1')
+        ], _get_filenames(conn_info, config, 'catalog1', export_products))
         mock_expand_wildcard.assert_called_with(conn_info, 'some/dir/*.csv')
 
     @patch('gobdistribute.distribute.Path')


### PR DESCRIPTION
The recurring distribute error came from this call. Export is too busy at the time distribute runs because of the database dump to the ref db thats occurring at the same time. That will be fixed later, but this PR makes sure we only fetch the export products for a certain catalogue once per job, so we can't fail on that mid-job.